### PR TITLE
removing all references to metadata dir

### DIFF
--- a/dev/scripts/build-linux-x86_64.sh
+++ b/dev/scripts/build-linux-x86_64.sh
@@ -17,7 +17,7 @@ mkdir -p $build_dir/drive/carts/screenshots/
 cargo build --release --target x86_64-unknown-linux-gnu
 
 # install files
-cp -r drive/carts/{games,labels,metadata,music} $build_dir/drive/carts
+cp -r drive/carts/{games,labels,music} $build_dir/drive/carts
 cp -r drive/carts/{*.p8,*.lua} $build_dir/drive/carts/
 cp drive/config_template.txt $build_dir/drive/config.txt
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,31 +133,6 @@ fn main() {
             cart.write(&mut label_file).unwrap();
             println!("generated label {label_path:?}");
 
-            // generate metadata file
-            let metadata = Cart {
-                id: 0,
-                title: name.clone().unwrap_or(cart_name.to_owned()),
-                filename: cart_name.to_owned(),
-                author: author.clone().unwrap_or_default(),
-                tags: String::new(),
-                likes: 0,
-                lid: String::new(),
-                download_url: String::new(),
-                description: String::new(),
-                thumb_url: String::new(),
-                favorite: false,
-            };
-
-            let metadata_serialized = serde_json::to_string_pretty(&metadata).unwrap();
-
-            let mut metadata_path = METADATA_DIR.clone().join(cart_name);
-            metadata_path.set_extension("json");
-            let mut metadata_file = File::create(metadata_path.clone()).unwrap();
-            metadata_file
-                .write_all(metadata_serialized.as_bytes())
-                .unwrap();
-            println!("generated metadata {metadata_path:?}");
-
             // generate music file
             let music_cart = match p8util::cart2music(&game_path) {
                 Ok(cart) => cart,

--- a/src/main.rs
+++ b/src/main.rs
@@ -575,20 +575,6 @@ async fn postprocess_cart(
             .map_err(|e| anyhow!("failed to write label file {label_path:?}: {e:?}"))?;
     }
 
-    // generate metadata file
-    /*
-    let mut metadata_path = METADATA_DIR.clone().join(filestem);
-    metadata_path.set_extension("json");
-    if !metadata_path.exists() {
-        let metadata_serialized = serde_json::to_string_pretty(cart).unwrap();
-
-        let mut metadata_file = File::create(metadata_path.clone()).unwrap();
-        metadata_file
-            .write_all(metadata_serialized.as_bytes())
-            .unwrap();
-    }
-    */
-
     // save metadata to db
     // TODO might be nicer to do batch insert instead of single query per cart?
     db.insert_cart(cart)?;


### PR DESCRIPTION
Had to remove these references to compile (alternatively, one could add the `drive/carts/metadata` directory and references back).