### PR TITLE
make pipes work on macos

### DIFF
--- a/drive/config.txt
+++ b/drive/config.txt
@@ -30,7 +30,7 @@ foreground_sleep_ms 2 // number of milliseconds to sleep each frame. Try 10 to c
 
 background_sleep_ms 10 // number of milliseconds to sleep each frame when running in the background
 
-sessions 925 // number of times program has been run
+sessions 942 // number of times program has been run
 
 // (scancode) hold this key down and left-click to simulate right-click
 rmb_key 0 // 0 for none  226 for LALT

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -216,12 +216,17 @@ pub trait PipeHAL {
 pub fn init_pipe_hal() -> Result<Box<dyn PipeHAL>> {
     #[cfg(target_os = "linux")]
     {
-        return Ok(Box::new(LinuxPipeHAL::init().unwrap()) as Box<dyn PipeHAL>);
+        return Ok(Box::new(MacosPipeHAL::init().unwrap()) as Box<dyn PipeHAL>);
     }
 
     #[cfg(target_os = "windows")]
     {
         return Ok(Box::new(WindowsPipeHAL::init().unwrap()) as Box<dyn PipeHAL>);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return Ok(Box::new(MacosPipeHAL::init().unwrap()) as Box<dyn PipeHAL>);
     }
 
     Ok(Box::new(DummyPipeHAL::init()) as Box<dyn PipeHAL>)

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,6 +311,8 @@ async fn main() {
                 } else {
                     format!("{},{}", cartdatas.len(), cartdatas_encoded)
                 };
+                println!("got {} carts", cartdatas.len());
+                println!("{data}");
                 pipe_hal.write_to_pico8(data).await;
             },
             "download" => {


### PR DESCRIPTION
current pico8 is not able to receive data from rust on macos, making a ton of functionality not work. investigate this